### PR TITLE
Download nltk corpus if not available

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -7,6 +7,13 @@ import string
 import pandas as pd
 import plotly.express as px
 from loguru import logger
+import nltk
+
+# Download the 'stopwords' corpus if it's not already present
+try:
+    nltk.download("corpora/stopwords")
+except Exception:
+    nltk.download("stopwords")
 from nltk.corpus import stopwords
 from wordcloud import WordCloud
 


### PR DESCRIPTION
Prior to this change, the `nltk` stopwords corpus would not have ben downloaded and this would throw an error.

This change programatically downloads the corpus if it doesn't exist.