### PR TITLE
Automagically download stopwords for real this time...

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -6,14 +6,10 @@ import string
 
 import pandas as pd
 import plotly.express as px
-from loguru import logger
 import nltk
 
 # Download the 'stopwords' corpus if it's not already present
-try:
-    nltk.download("corpora/stopwords")
-except Exception:
-    nltk.download("stopwords")
+nltk.data.find("corpora/stopwords")
 from nltk.corpus import stopwords
 from wordcloud import WordCloud
 


### PR DESCRIPTION
Prior to this change, the previous fix didnt work as it was opening an interactive downloading tool (what a time to be alive...).

This change updates the code to instead use the scripting equivalent.